### PR TITLE
ci_cd tests

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -62,8 +62,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
-    env:
-      UV_PYTHON: ${{ matrix.python-version }}
 
     steps:
       - uses: actions/checkout@v4
@@ -71,21 +69,22 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Download thedus package
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Download thedus dist
         uses: actions/download-artifact@v4
         with:
           name: dist
 
-      - name: Install dependencies
-        run: uv sync --dev
-
-      - name: Install thedus
+      - name: Install thedus from dist
         run: uv pip install dist/$(ls ./dist/ | grep ".tar.gz")
 
-      - name: Run tests
+      - name: Test with python ${{ matrix.python-version }}
         run: |
           mkdir -p ./tests/migrations
           pytest tests
+  
 
   publish_to_PyPi:
     runs-on: ubuntu-22.04

--- a/thedus/cmd/clickhouse_cmd.py
+++ b/thedus/cmd/clickhouse_cmd.py
@@ -3,7 +3,7 @@ import dataclasses
 import sys
 import logging
 from datetime import datetime
-from typing import List
+from typing import List, Union
 
 from ripley import ClickhouseProtocol
 from rich.console import Console
@@ -81,7 +81,7 @@ class _AbstractChangeDbStateCmd(AbstractCmd):
         sys.path.append(thedus_dir)
 
         self._clickhouse = clickhouse
-        self._migration_files: List[str] | None = None
+        self._migration_files: Union[List[str], None] = None
         self._to_revision = to_revision
         self._thedus_env = thedus_env
 

--- a/uv.lock
+++ b/uv.lock
@@ -287,8 +287,8 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "parameterized", specifier = "==0.9.0" },
-    { name = "pytest", specifier = ">=8.3.4" },
-    { name = "ruff", specifier = ">=0.9.1" },
+    { name = "pytest", specifier = ">=8.3.4,<9" },
+    { name = "ruff", specifier = ">=0.9.1,<1" },
 ]
 
 [[package]]


### PR DESCRIPTION
shorter with `subprocess.getoutput()`
fixed flapping tests ( [ORDER BY version](https://github.com/d-ganchar/thedus/compare/tests?expand=1#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR113) )